### PR TITLE
removed _id from foreign key attributes

### DIFF
--- a/BangazonAPI/fixtures/fillerdata.json
+++ b/BangazonAPI/fixtures/fillerdata.json
@@ -105,8 +105,8 @@
       "title": "armchair",
       "price": 100,
       "description": "Comfy lazyboy",
-      "customer_id": 2,
-      "product_type_id": 4
+      "customer": 2,
+      "product_type": 4
     }
   },
   {
@@ -115,8 +115,8 @@
       "title": "loveseat",
       "price": 200,
       "description": "Comfy ethanallen",
-      "customer_id": 6,
-      "product_type_id": 8
+      "customer": 6,
+      "product_type": 8
     }
   },
   {
@@ -125,8 +125,8 @@
       "title": "couch",
       "price": 300,
       "description": "Comfy serta",
-      "customer_id": 10,
-      "product_type_id": 1
+      "customer": 10,
+      "product_type": 1
     }
   },
   {
@@ -135,8 +135,8 @@
       "title": "director's chair",
       "price": 50,
       "description": "signed by hitchcock",
-      "customer_id": 3,
-      "product_type_id": 5
+      "customer": 3,
+      "product_type": 5
     }
   },
   {
@@ -145,8 +145,8 @@
       "title": "stool",
       "price": 100,
       "description": "metal",
-      "customer_id": 7,
-      "product_type_id": 9
+      "customer": 7,
+      "product_type": 9
     }
   },
   {
@@ -155,8 +155,8 @@
       "title": "fake plant",
       "price": 80,
       "description": "purifies air",
-      "customer_id": 9,
-      "product_type_id": 6
+      "customer": 9,
+      "product_type": 6
     }
   },
   {
@@ -165,8 +165,8 @@
       "title": "rug",
       "price": 110,
       "description": "ties room together",
-      "customer_id": 4,
-      "product_type_id": 3
+      "customer": 4,
+      "product_type": 3
     }
   },
   {
@@ -175,8 +175,8 @@
       "title": "armchair",
       "price": 200,
       "description": "tasteful upholstry",
-      "customer_id": 2,
-      "product_type_id": 1
+      "customer": 2,
+      "product_type": 1
     }
   },
   {
@@ -185,8 +185,8 @@
       "title": "armchair",
       "price": 1000,
       "description": "reclines",
-      "customer_id": 1,
-      "product_type_id": 1
+      "customer": 1,
+      "product_type": 1
     }
   },
   {
@@ -195,8 +195,8 @@
       "title": "desk",
       "price": 900,
       "description": "wood",
-      "customer_id": 3,
-      "product_type_id": 7
+      "customer": 3,
+      "product_type": 7
     }
   },
   {
@@ -393,8 +393,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "active",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -403,8 +403,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "active",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -413,8 +413,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "inactive",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -423,8 +423,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "inactive",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -433,8 +433,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "active",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -443,8 +443,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "active",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -453,8 +453,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "inactive",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -463,8 +463,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "inactive",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -473,8 +473,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "active",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -483,8 +483,8 @@
     "model": "BangazonAPI.order",
     "fields": {
       "order_status": "inactive",
-      "payment_types_id": 1,
-      "purchase_customer_id": 5
+      "payment_types": 1,
+      "purchase_customer": 5
 
     }
 
@@ -493,8 +493,8 @@
   {
     "model": "BangazonAPI.orderproduct",
     "fields": {
-      "product_id": 3,
-      "order_id": 1
+      "product": 3,
+      "order": 1
 
     }
 
@@ -503,8 +503,8 @@
   {
     "model": "BangazonAPI.orderproduct",
     "fields": {
-      "product_id": 2,
-      "order_id": 2
+      "product": 2,
+      "order": 2
 
     }
 
@@ -513,8 +513,8 @@
   {
     "model": "BangazonAPI.orderproduct",
     "fields": {
-      "product_id": 4,
-      "order_id": 3
+      "product": 4,
+      "order": 3
 
     }
 
@@ -523,8 +523,8 @@
   {
     "model": "BangazonAPI.orderproduct",
     "fields": {
-      "product_id": 5,
-      "order_id": 4
+      "product": 5,
+      "order": 4
 
     }
 
@@ -533,8 +533,8 @@
   {
     "model": "BangazonAPI.orderproduct",
     "fields": {
-      "product_id": 5,
-      "order_id": 5
+      "product": 5,
+      "order": 5
 
     }
 
@@ -544,8 +544,8 @@
     "model": "BangazonAPI.orderproduct",
     "pk": 6,
     "fields": {
-      "product_id": 6,
-      "order_id": 6
+      "product": 6,
+      "order": 6
 
     }
 
@@ -554,8 +554,8 @@
   {
     "model": "BangazonAPI.orderproduct",
     "fields": {
-      "product_id": 7,
-      "order_id": 7
+      "product": 7,
+      "order": 7
 
   }
 
@@ -564,8 +564,8 @@
   {
     "model": "BangazonAPI.orderproduct",
     "fields": {
-      "product_id": 8,
-      "order_id": 7
+      "product": 8,
+      "order": 7
 
     }
 
@@ -574,8 +574,8 @@
   {
     "model": "BangazonAPI.orderproduct",
     "fields": {
-      "product_id": 9,
-      "order_id": 9
+      "product": 9,
+      "order": 9
 
     }
 
@@ -781,7 +781,7 @@
     "first_name": "Milton",
     "last_name": "Pouncy",
     "title": "Supervisor",
-    "department_id": "1"
+    "department": "1"
   }
 },
 
@@ -791,7 +791,7 @@
     "first_name": "Bad",
     "last_name": "Larry",
     "title": "Lead Developer",
-    "department_id": "1"
+    "department": "1"
   }
 },
 {
@@ -800,7 +800,7 @@
     "first_name": "Arnie",
     "last_name": "Pecanroll",
     "title": "Workerbee",
-    "department_id": "2"
+    "department": "2"
   }
 },
 {
@@ -809,7 +809,7 @@
     "first_name": "Samwise",
     "last_name": "Ganges",
     "title": "Workerbee",
-    "department_id": "3"
+    "department": "3"
   }
 },
 {
@@ -818,7 +818,7 @@
     "first_name": "Fanny",
     "last_name": "Doggonit",
     "title": "Supervisor",
-    "department_id": "4"
+    "department": "4"
   }
 },
 {
@@ -827,7 +827,7 @@
     "first_name": "Ashley",
     "last_name": "Winfrey",
     "title": "Secretary",
-    "department_id": "5"
+    "department": "5"
   }
 },
 {
@@ -836,7 +836,7 @@
     "first_name": "Jens",
     "last_name": "Farfignuget",
     "title": "Coffeeguy",
-    "department_id": "6"
+    "department": "6"
   }
 },
 {
@@ -845,7 +845,7 @@
     "first_name": "Parcheesy",
     "last_name": "Patterpants",
     "title": "Kittykat",
-    "department_id": "7"
+    "department": "7"
   }
 },
 {
@@ -854,7 +854,7 @@
     "first_name": "Randy",
     "last_name": "Maxwellhouse",
     "title": "Supervisor",
-    "department_id": "8"
+    "department": "8"
   }
 },
 {
@@ -863,7 +863,7 @@
     "first_name": "Winston",
     "last_name": "Theghosbuster",
     "title": "Supervisor",
-    "department_id": "9"
+    "department": "9"
   }
 }
 

--- a/BangazonAPI/models.py
+++ b/BangazonAPI/models.py
@@ -76,8 +76,8 @@ class Product(models.Model):
     title = models.CharField(max_length=25)
     price = models.DecimalField(max_digits=6, decimal_places=2)
     description = models.CharField(max_length=100)
-    customer_id = models.ForeignKey(Customer)
-    product_type_id = models.ForeignKey(ProductType)
+    customer= models.ForeignKey(Customer)
+    product_type = models.ForeignKey(ProductType)
 
     def __str__(self):
         """
@@ -121,8 +121,8 @@ class Order(models.Model):
     """
 
     order_status = models.CharField(max_length = 25)
-    payment_types_id = models.ForeignKey(PaymentType)
-    purchase_customer_id = models.ForeignKey(Customer)
+    payment_types = models.ForeignKey(PaymentType)
+    purchase_customer = models.ForeignKey(Customer)
 
 class OrderProduct(models.Model):
     """
@@ -135,8 +135,8 @@ class OrderProduct(models.Model):
     Order_id: foreign key identifier for order in orderproduct
     Product_id: foreign key identifier for Product in orderproduct
     """ 
-    order_id = models.ForeignKey(Order)
-    product_id = models.ForeignKey(Product)
+    order = models.ForeignKey(Order)
+    product = models.ForeignKey(Product)
 
 
 class TrainingCourse(models.Model):
@@ -176,6 +176,7 @@ class Department(models.Model):
     name = models.CharField(max_length=25)
     expense_budget = models.DecimalField(max_digits=10, decimal_places=2)
 
+
 class Employee(models.Model):
     """
     This class defines a Employee in a table of employees.
@@ -192,7 +193,7 @@ class Employee(models.Model):
     first_name = models.CharField(max_length=25)
     last_name = models.CharField(max_length=25)
     title = models.CharField(max_length=25)
-    department_id = models.ForeignKey(Department)
+    department = models.ForeignKey(Department)
     
 
     def __str__(self):

--- a/BangazonAPI/serializers.py
+++ b/BangazonAPI/serializers.py
@@ -26,7 +26,7 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
 
         model = Product
         fields = ('title', 'price', 'description',
-                  'customer_id', 'product_type_id')
+                  'customer', 'product_type')
 
 
 class PaymentTypeSerializer(serializers.HyperlinkedModelSerializer):
@@ -58,7 +58,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         """Global Options for Order Class auth:Angela """
         model = Order
-        fields = ('order_status', 'payment_types_id', 'purchase_customer_id')
+        fields = ('order_status', 'payment_types', 'purchase_customer')
 
 class OrderProductSerializer(serializers.HyperlinkedModelSerializer):
     """
@@ -68,7 +68,7 @@ class OrderProductSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         """ Global options for OrderProduct class """
         model = OrderProduct
-        fields = ('product_id', 'order_id')
+        fields = ('product', 'order')
 
 class TrainingCourseSerializer(serializers.HyperlinkedModelSerializer):
     """
@@ -99,4 +99,4 @@ class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta: 
         """ Global options for OrderProduct class """
         model = Employee
-        fields = ('first_name', 'last_name', 'title', 'department_id')
+        fields = ('first_name', 'last_name', 'title', 'department')


### PR DESCRIPTION
# Overview
  - removed '_id' from foreign key attributes in models, serializers, and filler data
  
## Changed Content 
  - if attribute in above files was product_id, for example, it is now product
  
## Completed/Still Needed
  - teammates need to verify changes do not conflict with anything on their machines after pulling down new master, deleting migrations and db, loading json filler data and running server.
  
## Testing
  - ensure changes merge with branches about to be merged
  
## Documentation 
  - django automatically adds a _id to foreign key variables, so we don't want to confuse it